### PR TITLE
IP addresses are now anonymized per suggestions from Jim.

### DIFF
--- a/source/views/layouts/partials/_head.html.erb
+++ b/source/views/layouts/partials/_head.html.erb
@@ -11,6 +11,7 @@
 
       ga('create', '<%= config_item :ga_id %>', 'service.gov.uk');
       <%= yield :analytics %>
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
     </script>
     <% end %>


### PR DESCRIPTION
Jim suggested that we should ask GA to anonymize IP addresses coming in via our analytics scripts. This change makes that happen.
