### PR TITLE
Add phase indicator gutter fix.

### DIFF
--- a/source/assets/stylesheets/_shame.scss
+++ b/source/assets/stylesheets/_shame.scss
@@ -1,0 +1,26 @@
+/* Phase indicator alignment fixes */
+.indicator {
+  padding: 0.5em 2em !important;
+
+  @include media(mobile){
+    padding: 0.5em 1em !important;
+  }
+
+  p {
+    padding: 0 !important;
+
+    /* Set uppercase font for indicator phase */
+    strong {
+      text-transform: uppercase;
+    }
+  }
+
+  /* Set alpha bar to white text */
+  body.alpha & {
+    p,
+    a:visited,
+    a:link { 
+      color: $white; 
+    }
+  }
+}

--- a/source/assets/stylesheets/moj-template.css.scss
+++ b/source/assets/stylesheets/moj-template.css.scss
@@ -9,8 +9,6 @@
 @import "design-patterns/buttons";
 @import "design-patterns/alpha-beta";
 
-// SHAME - files waiting to be removed
-
 // Core MOJ Styles
 @import "moj-core/helpers";
 @import "moj-core/moj-colours";
@@ -23,3 +21,7 @@
 @import "design-patterns/breadcrumb";
 @import "design-patterns/button";
 @import "design-patterns/footer";
+
+
+// SHAME - quick fix issues
+@import "shame";


### PR DESCRIPTION
Add a patch to fix proposition header gutter on smaller devices. 
Currently in 'shame' file. Can be removed when this PR is merged and the template is updated to relevant version of govuk_frontend_toolkit:
https://github.com/alphagov/govuk_frontend_toolkit/pull/91
