### PR TITLE
Custom support links

### DIFF
--- a/source/views/layouts/partials/_footer_support_links.html.erb
+++ b/source/views/layouts/partials/_footer_support_links.html.erb
@@ -1,19 +1,15 @@
-<% if content_for?(:footer_support_links_override) %>
-              <%= yield(:footer_support_links_override) %>
-            <% else %>
-              <h2 class="visuallyhidden">Support links</h2>
-              <ul>
-                <% if content_for?(:footer_app_links) %>
-                  <%= yield(:footer_app_links) %>
-                <% else %>
-                  <li><a href="http://www.gov.uk/help">Help</a></li>
-                  <li><a href="http://www.gov.uk/help/cookies">Cookies</a></li>
-                  <li><a href="http://www.gov.uk/contact">Contact</a></li>
-                  <li><a href="http://www.gov.uk/cymraeg">Cymraeg</a></li>
-                <% end %>
-                <li>
-                  Built by the
-                  <a href="https://mojdigital.blog.gov.uk/"><abbr title="Ministry of Justice">MOJ</abbr> Digital Services</a>
-                </li>
-              </ul>
-            <% end %>
+<h2 class="visuallyhidden">Support links</h2>
+            <ul>
+              <% if content_for?(:footer_app_links) %>
+                <%= yield(:footer_app_links) %>
+              <% else %>
+                <li><a href="http://www.gov.uk/help">Help</a></li>
+                <li><a href="http://www.gov.uk/help/cookies">Cookies</a></li>
+                <li><a href="http://www.gov.uk/contact">Contact</a></li>
+                <li><a href="http://www.gov.uk/cymraeg">Cymraeg</a></li>
+              <% end %>
+              <li>
+                Built by the
+                <a href="https://mojdigital.blog.gov.uk/"><abbr title="Ministry of Justice">MOJ</abbr> Digital Services</a>
+              </li>
+            </ul>


### PR DESCRIPTION
In hindsight, perhaps the symbol should be something other than "_override" as this does not actually allow you to override the include, only the 4 links? But I wanted this to allow the most common usage.
