### PR TITLE
Remove js-enabled class for IE6

### DIFF
--- a/source/views/layouts/partials/_after_header.html.erb
+++ b/source/views/layouts/partials/_after_header.html.erb
@@ -1,4 +1,5 @@
-<div class="indicator cf">
+<!--[if gt IE 6]><!--><script>document.body.className = document.body.className.replace('js-enabled','');</script><!--<![endif]-->
+    <div class="indicator cf">
       <p>
         <strong><%= config_item(:phase).to_s.capitalize %>:</strong>
         This is a new service -


### PR DESCRIPTION
Remove js-enabled class from body for IE6 as JavaScript is not included for IE6.
