### PR TITLE
Remove phase tag from proposition header

### DIFF
--- a/source/views/layouts/partials/_proposition_header.html.erb
+++ b/source/views/layouts/partials/_proposition_header.html.erb
@@ -4,7 +4,6 @@
         <div class="header-proposition">
           <div class="content">
             <a href="/" id="proposition-name"><%= "#{config_item(:proposition_title)}" %></a>
-            <a href="https://www.gov.uk/service-manual/phases/<%= "#{config_item(:phase).to_s.downcase}" %>.html" class="proposition-phase"><%= "#{config_item(:phase).to_s.capitalize}" %></a>
             <%= yield(:proposition_links) %>
           </div>
         </div>


### PR DESCRIPTION
To match latest GDS phase banner design pattern
