### PR TITLE
Allow apps to determine IE version for JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ In order for these files to work, you will need to set a number of variables in 
     config.product_type = ''
     # Feedback URL (URL for feedback link in phase banner)
     config.feedback_url = ''
+    # Supply JavaScript to IE greater than version specified
+    config.js_gt_ie = 6
     # Google Analytics ID (Tracking ID for the service)
     config.ga_id = ''
 

--- a/source/views/layouts/partials/_body_end.html.erb
+++ b/source/views/layouts/partials/_body_end.html.erb
@@ -1,4 +1,4 @@
-<!--[if gt IE 6]><!-->
+<!--[if gt IE <%= config_item(:js_gt_ie) %>]><!-->
     <script src="<%= asset_path "vendor/jquery/jquery-1.11.0.min.js" %>" type="text/javascript"></script>
     <script src="<%= asset_path "moj.js" %>" type="text/javascript"></script>
 


### PR DESCRIPTION
I have a case where JS is required for IE6. But rather than revert the `[if gt IE 6]`, this allows us to specify a version in each app.
