### PR TITLE
a hover underline is now in govuk_template

### DIFF
--- a/source/assets/stylesheets/design-patterns/_proposition-header.scss
+++ b/source/assets/stylesheets/design-patterns/_proposition-header.scss
@@ -6,9 +6,6 @@
   #proposition-name {
     line-height: 1em;
     display: inline-block;
-    &:hover {
-      border-bottom: 1px solid $white;
-    }
   }
 
   body.alpha & .proposition-phase {
@@ -23,5 +20,5 @@
     text-decoration: none;
     position: relative;
     top: -3px;
-  } 
+  }
 }


### PR DESCRIPTION
So, as of right now, you get 2 underlines. See attached.
![screen shot 2015-02-03 at 17 21 10](https://cloud.githubusercontent.com/assets/69542/6025712/aba3fee4-abcc-11e4-9498-cb14650699ec.png)

govuk_template change: https://github.com/alphagov/govuk_template/commit/4b2d06ce5db11b47dd3dbf38b371734d598db8f7