### PR TITLE
Js gt ie template block

### DIFF
--- a/build_tools/compiler/django_processor.rb
+++ b/build_tools/compiler/django_processor.rb
@@ -18,7 +18,8 @@ module Compiler
       page_title: "{% block page_title %}{% endblock %}",
       top_of_page: "{% load staticfiles %}{% block top_of_page %}{% endblock %}",
       stylesheets: "{% block stylesheets %}{% endblock %}",
-      javascripts: "{% block javascripts %}{% endblock %}"
+      javascripts: "{% block javascripts %}{% endblock %}",
+      js_gt_ie: "{% block js_gt_ie %}5{% endblock %}"
     }
 
     def handle_yield(section = :layout)

--- a/build_tools/compiler/jinja_processor.rb
+++ b/build_tools/compiler/jinja_processor.rb
@@ -18,7 +18,8 @@ module Compiler
       page_title: "{% block page_title %}{% endblock %}",
       top_of_page: "{% block top_of_page %}{% endblock %}",
       stylesheets: "{% block stylesheets %}{% endblock %}",
-      javascripts: "{% block javascripts %}{% endblock %}"
+      javascripts: "{% block javascripts %}{% endblock %}",
+      js_gt_ie: "{% block js_gt_ie %}5{% endblock %}"
     }
 
     def handle_yield(section = :layout)

--- a/build_tools/compiler/liquid_processor.rb
+++ b/build_tools/compiler/liquid_processor.rb
@@ -19,7 +19,8 @@ module Compiler
       page_title: "{% include layouts/_page_title.html %}",
       top_of_page: "{% include layouts/_top_of_page.html %}",
       stylesheets: "{% include layouts/_stylesheets.html %}",
-      javascripts: "{% include layouts/_javascripts.html %}"
+      javascripts: "{% include layouts/_javascripts.html %}",
+      js_gt_ie: "{{ js_gt_ie }}"
     }
 
     def handle_yield(section = :layout)

--- a/build_tools/compiler/mustache_inheritance_processor.rb
+++ b/build_tools/compiler/mustache_inheritance_processor.rb
@@ -19,7 +19,8 @@ module Compiler
       page_title: "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
       top_of_page: "{{$topOfPage}}{{/topOfPage}}",
       stylesheets: "{{$stylesheets}}{{/stylesheets}}",
-      javascripts: "{{$javascripts}}{{/javascripts}}"
+      javascripts: "{{$javascripts}}{{/javascripts}}",
+      js_gt_ie: "{{$js_gt_ie}}5{{/js_gt_ie}}"
     }
 
     def handle_yield(section = :layout)

--- a/build_tools/compiler/mustache_processor.rb
+++ b/build_tools/compiler/mustache_processor.rb
@@ -19,7 +19,8 @@ module Compiler
       page_title: "{{ pageTitle }}",
       top_of_page: "{{{ topOfPage }}}",
       stylesheets: "{{{ stylesheets }}}",
-      javascripts: "{{{ javascripts }}}"
+      javascripts: "{{{ javascripts }}}",
+      js_gt_ie: "{{{ js_gt_ie }}}"
     }
 
     def handle_yield(section)

--- a/build_tools/compiler/play_processor.rb
+++ b/build_tools/compiler/play_processor.rb
@@ -38,6 +38,8 @@ module Compiler
         "@footerTop"
       when :footer_support_links
         "@footerLinks"
+      when :js_gt_ie
+        "@js_gt_ie.getOrElse(\"5\")"
       else
         ""
       end


### PR DESCRIPTION
Using the app to generate the various templates would skip rendering the blocks for the JavaScript minimum IE version conditional tag, due to missing relevant key in each of the language processors, which would then render as 'empty' when used within the chosen framework: `<!--[if gt IE ]><!-->`. This renders as text in IE6, and doesn't stop the scripts from being loaded.

The key has now been added to all the language compilers to fix.